### PR TITLE
Fixed default configuration setting. Changed from 1 day to 15 minutes.

### DIFF
--- a/lib/devise_jwt_auth/engine.rb
+++ b/lib/devise_jwt_auth/engine.rb
@@ -33,7 +33,7 @@ module DeviseJwtAuth
 
   self.send_new_access_token_on_each_request     = false
   self.refresh_token_lifespan                    = 1.week
-  self.access_token_lifespan                     = 1.day
+  self.access_token_lifespan                     = 15.minutes
   self.refresh_token_name                        = 'refresh-token'
   self.access_token_name                         = 'access-token'
   self.refresh_token_encryption_key              = 'your-refresh-token-secret-key-here'


### PR DESCRIPTION
Pretty self explanatory. Access tokens generally last between 10 and 15 minutes. This is what the default should be.